### PR TITLE
Flat structure aka big markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This will ask you for a password, but the password will not be saved (a refresh 
 In case you have multiple shops under your pocketbook account, you can fill the "Shop name" you want to use (substring of the name is enough).
 The "Import Folder" is where your highlights will be saved to.
 
+You can choose between a flat structure or a nested structure.
+The nested structure creates separate files for each highlight and uses DataView to aggregate them in the parent file.
+
 ## Usage
 
 After setup, you can find the pocketbook cloud highlight import in the command palette.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "obsidian-sample-plugin",
-  "version": "1.0.0",
+  "name": "pocketbook-cloud-highlight-importer",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-sample-plugin",
-      "version": "1.0.0",
+      "name": "pocketbook-cloud-highlight-importer",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "epub-cfi-resolver": "^1.0.1"

--- a/src/apiclient.ts
+++ b/src/apiclient.ts
@@ -1,4 +1,4 @@
-import { requestUrl } from 'obsidian';
+import { Notice, requestUrl } from 'obsidian';
 import PocketbookCloudHighlightsImporterPlugin from './main';
 
 export interface PocketbookCloudBookCover {
@@ -188,6 +188,19 @@ export class PocketbookCloudLoginClient {
   ) {}
 
   async login() {
+    // Validate required parameters
+    if (!this.username || this.username.trim() === '') {
+      new Notice('❌ Error: Username is required and cannot be empty');
+    }
+
+    if (!this.client_id || this.client_id.trim() === '') {
+      new Notice('❌ Error: Client ID is required and cannot be empty');
+    }
+
+    if (!this.client_secret || this.client_secret.trim() === '') {
+      new Notice('❌ Error: Client secret is required and cannot be empty');
+    }
+
     const shops: PocketbookCloudShopInfo[] = await fetch(
       'https://cloud.pocketbook.digital/api/v1.0/auth/login?' +
         new URLSearchParams({

--- a/src/import.ts
+++ b/src/import.ts
@@ -33,7 +33,8 @@ function general_book_content(book: PocketbookCloudBook, folder: string) {
     '`);\n\n' +
     'const result = queryResult.value.values.map(line => "> [!quote]\\n> " + line[0].replace(/\\n/g, "\\n> ") + (line[1] ? "\\n\\n> [!note]\\n> " + line[1].replace(/\\n/g, "\\n> ") : ""))\n\n' +
     'dv.list(result)\n' +
-    '```\n';
+    '```\n' +
+    `Authors: [[${book.metadata.authors}]]\n`;
   return content;
 }
 

--- a/src/import.ts
+++ b/src/import.ts
@@ -3,7 +3,7 @@ import { PocketbookCloudApiClient, PocketbookCloudBook, PocketbookCloudLoginClie
 import PocketbookCloudHighlightsImporterPlugin from './main';
 import { PocketbookCloudHighlightsImporterPluginSettings } from './settings';
 
-import CFI from 'epub-cfi-resolver';
+const CFI = require('epub-cfi-resolver');
 
 function dataViewStructure(folder: string, book: PocketbookCloudBook) {
   return (

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,9 +1,41 @@
 import { App, Notice, TFile, stringifyYaml } from 'obsidian';
-import { PocketbookCloudApiClient, PocketbookCloudLoginClient } from './apiclient';
+import { PocketbookCloudApiClient, PocketbookCloudBook, PocketbookCloudLoginClient, PocketbookCloudNote } from './apiclient';
 import PocketbookCloudHighlightsImporterPlugin from './main';
 import { PocketbookCloudHighlightsImporterPluginSettings } from './settings';
 
 const CFI = require('epub-cfi-resolver');
+
+function general_book_content(book: PocketbookCloudBook, folder: string) {
+  const book_yaml_frontmatter = {
+    title: book.title,
+    authors: book.metadata.authors,
+    isbn: book.metadata.isbn,
+    year: book.metadata.year,
+    id: book.id,
+    fast_hash: book.fast_hash,
+    collections: (book.collections ?? '').split(','),
+    uploaded_at: book.created_at,
+    read_status: book.read_status,
+    type: 'book',
+    plugin: 'pocketbook-cloud-highlights-importer',
+  };
+  const content = // not using multiline strings because they mess up indentation
+    '---\n' +
+    stringifyYaml(book_yaml_frontmatter) +
+    '---\n\n' +
+    '```dataviewjs\n' +
+    'dv.header(2, dv.current().title)\n' +
+    'const queryResult = await dv.query(`\n' +
+    '  TABLE WITHOUT ID text, note\n' +
+    `  FROM "${folder}/highlights"\n` +
+    `  WHERE book_id="${book.id}" AND type = "highlight" and plugin = "pocketbook-cloud-highlights-importer"\n` +
+    '  SORT sort_order\n' +
+    '`);\n\n' +
+    'const result = queryResult.value.values.map(line => "> [!quote]\\n> " + line[0].replace(/\\n/g, "\\n> ") + (line[1] ? "\\n\\n> [!note]\\n> " + line[1].replace(/\\n/g, "\\n> ") : ""))\n\n' +
+    'dv.list(result)\n' +
+    '```\n';
+  return content;
+}
 
 export class PocketbookCloudHighlightsImporter {
   login_client: PocketbookCloudLoginClient;
@@ -17,7 +49,7 @@ export class PocketbookCloudHighlightsImporter {
       settings.shop_name,
       settings.access_token,
       settings.refresh_token,
-      settings.access_token_valid_until
+      settings.access_token_valid_until,
     );
     this.api_client = new PocketbookCloudApiClient(this.login_client);
   }
@@ -26,94 +58,123 @@ export class PocketbookCloudHighlightsImporter {
     new Notice('Importing highlights...');
     const books = await this.api_client.getBooks();
 
-    for (const book of books) {
+    new Notice('Importing ' + books.length + ' books.');
+
+    for (const book of books.slice(0,3)) {
       new Notice(`Importing ${book.title}`);
       const highlightIds = await this.api_client.getHighlightIdsForBook(book.fast_hash);
 
       const highlights = await Promise.all(highlightIds.map(highlightInfo => this.api_client.getHighlight(highlightInfo.uuid, book.fast_hash)));
       if (highlights.length > 0) {
         const sanitized_book_title = book.title.replace(/[\.#%&{}\\<>*\?/$!'":@+`|=]/g, '');
-        const folder = `${this.settings.import_folder}/${sanitized_book_title}`;
-        this.createFolder(folder);
-        this.createFolder(`${folder}/highlights`);
-
-        const metadata_filename = `${folder}/metadata.md`;
-
-        // does not work for now, see API client comment
-        //const cover_filename = `${folder}/cover.jpg`;
-        //await this.writeFileBinary(cover_filename, await this.api_client.getBookCover(book));
-
-        // write metadata file, which should be used to get all highlights together
-        const book_yaml_frontmatter = {
-          title: book.title,
-          authors: book.metadata.authors,
-          isbn: book.metadata.isbn,
-          year: book.metadata.year,
-          id: book.id,
-          fast_hash: book.fast_hash,
-          collections: (book.collections ?? '').split(','),
-          uploaded_at: book.created_at,
-          read_status: book.read_status,
-          type: 'book',
-          plugin: 'pocketbook-cloud-highlights-importer',
-        };
-        const content = // not using multiline strings because they mess up indentation
-          '---\n' +
-          stringifyYaml(book_yaml_frontmatter) +
-          '---\n\n' +
-          '```dataviewjs\n' +
-          'dv.header(2, dv.current().title)\n' +
-          'const queryResult = await dv.query(`\n' +
-          '  TABLE WITHOUT ID text, note\n' +
-          `  FROM "${folder}/highlights"\n` +
-          `  WHERE book_id="${book.id}" AND type = "highlight" and plugin = "pocketbook-cloud-highlights-importer"\n` +
-          '  SORT sort_order\n' +
-          '`);\n\n' +
-          'const result = queryResult.value.values.map(line => "> [!quote]\\n> " + line[0].replace(/\\n/g, "\\n> ") + (line[1] ? "\\n\\n> [!note]\\n> " + line[1].replace(/\\n/g, "\\n> ") : ""))\n\n' +
-          'dv.list(result)\n' +
-          '```\n';
-        await this.writeFile(metadata_filename, content);
-
-        //TODO: only create the CFI object once m)
-        try {
-          // if sorting works, fine. if not, also fine, using date then.
-          highlights.sort((a, b) => CFI.compare(this.cfi(a.quotation.begin), this.cfi(b.quotation.begin)));
-        } catch (e) {
-          highlights.sort((a, b) => +a.quotation?.updated - +b.quotation?.updated);
-        }
-
-        let i = 0;
-        for (const highlight of highlights) {
-          i++;
-          const file_name = `${folder}/highlights/${highlight.uuid}.md`;
-          const highlight_yaml_frontmatter = {
-            id: highlight.uuid,
-            book_id: book.id,
-            book_fast_hash: book.fast_hash,
-            color: highlight.color?.value ?? 'unknown',
-            note: highlight.note?.text ?? '',
-            text: highlight.quotation?.text ?? '',
-            pointer: {
-              begin: highlight.quotation?.begin ?? '',
-              end: highlight.quotation?.end ?? '',
-            },
-            updated: highlight.quotation?.updated,
-            type: 'highlight',
-            plugin: 'pocketbook-cloud-highlights-importer',
-            sort_order: i,
-          };
-          const content = // not using multiline strings because they mess up indentation
-            '---\n' +
-            stringifyYaml(highlight_yaml_frontmatter) +
-            '---\n\n' +
-            `> [!quote]\n> ${(highlight.quotation?.text ?? '').replace(/\n/g, '\n> ')}\n\n` + //
-            (highlight.note?.text ? `> [!note]\n> ${(highlight.note?.text ?? '').replace(/\n/g, '\n> ')}\n` : '');
-          await this.writeFile(file_name, content);
+        if (this.plugin.settings.flat_structure) {
+          this.writeFlatHighlights(book, sanitized_book_title, highlights)
+        } else {
+          this.writeNestedHighlights(book, sanitized_book_title, highlights);
         }
       }
     }
+  }
 
-    new Notice('Import done');
+  private async writeNestedHighlights(book: PocketbookCloudBook, title: string, highlights: PocketbookCloudNote[]) {
+    const folder = `${this.settings.import_folder}/${title}`;
+    this.createFolder(folder);
+    this.createFolder(`${folder}/highlights`);
+
+    const metadata_filename = `${folder}/metadata.md`;
+
+    // does not work for now, see API client comment
+    //const cover_filename = `${folder}/cover.jpg`;
+    //await this.writeFileBinary(cover_filename, await this.api_client.getBookCover(book));
+
+
+    const content = general_book_content(book, folder);
+    await this.writeFile(metadata_filename, content);
+
+    //TODO: only create the CFI object once m)
+    try {
+      // if sorting works, fine. if not, also fine, using date then.
+      highlights.sort((a, b) => CFI.compare(this.cfi(a.quotation.begin), this.cfi(b.quotation.begin)));
+    } catch (e) {
+      highlights.sort((a, b) => +a.quotation?.updated - +b.quotation?.updated);
+    }
+
+    let i = 0;
+    for (const highlight of highlights) {
+      i++;
+      const file_name = `${folder}/highlights/${highlight.uuid}.md`;
+      const highlight_yaml_frontmatter = {
+        id: highlight.uuid,
+        book_id: book.id,
+        book_fast_hash: book.fast_hash,
+        color: highlight.color?.value ?? 'unknown',
+        note: highlight.note?.text ?? '',
+        text: highlight.quotation?.text ?? '',
+        pointer: {
+          begin: highlight.quotation?.begin ?? '',
+          end: highlight.quotation?.end ?? '',
+        },
+        updated: highlight.quotation?.updated,
+        type: 'highlight',
+        plugin: 'pocketbook-cloud-highlights-importer',
+        sort_order: i,
+      };
+      const content = // not using multiline strings because they mess up indentation
+        '---\n' +
+        stringifyYaml(highlight_yaml_frontmatter) +
+        '---\n\n' +
+        `> [!quote]\n> ${(highlight.quotation?.text ?? '').replace(/\n/g, '\n> ')}\n\n` + //
+        (highlight.note?.text ? `> [!note]\n> ${(highlight.note?.text ?? '').replace(/\n/g, '\n> ')}\n` : '');
+      await this.writeFile(file_name, content);
+    }
+  }
+
+
+  private async writeFlatHighlights(book: PocketbookCloudBook, title: string, highlights: PocketbookCloudNote[]) {
+    const folder = `${this.settings.import_folder}`;
+    await this.createFolder(folder);
+
+    const file_name = `${folder}/${title}.md`;
+
+    // write metadata file, which should be used to get all highlights together
+    const content = general_book_content(book, folder);
+    await this.writeFile(file_name, content);
+
+    //TODO: only create the CFI object once m)
+    try {
+      // if sorting works, fine. if not, also fine, using date then.
+      highlights.sort((a, b) => CFI.compare(this.cfi(a.quotation.begin), this.cfi(b.quotation.begin)));
+    } catch (e) {
+      highlights.sort((a, b) => +a.quotation?.updated - +b.quotation?.updated);
+    }
+
+    let i = 0;
+    for (const highlight of highlights) {
+      i++;
+      const highlight_yaml_frontmatter = {
+        id: highlight.uuid,
+        book_id: book.id,
+        book_fast_hash: book.fast_hash,
+        color: highlight.color?.value ?? 'unknown',
+        note: highlight.note?.text ?? '',
+        text: highlight.quotation?.text ?? '',
+        pointer: {
+          begin: highlight.quotation?.begin ?? '',
+          end: highlight.quotation?.end ?? '',
+        },
+        updated: highlight.quotation?.updated,
+        type: 'highlight',
+        plugin: 'pocketbook-cloud-highlights-importer',
+        sort_order: i,
+      };
+      const content = // not using multiline strings because they mess up indentation
+        '---\n' +
+        stringifyYaml(highlight_yaml_frontmatter) +
+        '---\n\n' +
+        `> [!quote]\n> ${(highlight.quotation?.text ?? '').replace(/\n/g, '\n> ')}\n\n` + //
+        (highlight.note?.text ? `> [!note]\n> ${(highlight.note?.text ?? '').replace(/\n/g, '\n> ')}\n` : '');
+      await this.writeOrAppendFile(file_name, content);
+    }
   }
 
   private async createFolder(folder: string) {
@@ -132,6 +193,23 @@ export class PocketbookCloudHighlightsImporter {
       throw new Error(`File ${file_name} is not a TFile, can only write to files.`);
     }
   }
+
+  private async writeOrAppendFile(file_name: string, content: string) {
+    const file = this.app.vault.getAbstractFileByPath(file_name);
+    if (!file) {
+      await this.app.vault.create(file_name, content);
+    } else if (file instanceof TFile) {
+      await this.appendToFile(file, content);
+    } else {
+      throw new Error(`File ${file_name} is not a TFile, can only write to files.`);
+    }
+  }
+
+  async appendToFile(file: TFile, content: string) {
+    const existingContent = await this.app.vault.read(file);
+    await this.app.vault.modify(file, existingContent + "\n" + content);
+  }
+
 
   private async writeFileBinary(file_name: string, content: ArrayBuffer) {
     const file = this.app.vault.getAbstractFileByPath(file_name) as TFile;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ export interface PocketbookCloudHighlightsImporterPluginSettings {
   access_token_valid_until: Date;
   refresh_token: string;
   import_folder: string;
+  flat_structure: boolean,
 }
 
 export const DEFAULT_SETTINGS: PocketbookCloudHighlightsImporterPluginSettings = {
@@ -18,6 +19,7 @@ export const DEFAULT_SETTINGS: PocketbookCloudHighlightsImporterPluginSettings =
   access_token_valid_until: new Date(),
   refresh_token: '',
   import_folder: '',
+  flat_structure: true,
 };
 
 export class PocketbookCloudHighlightsImporterSettingTab extends PluginSettingTab {
@@ -108,6 +110,19 @@ export class PocketbookCloudHighlightsImporterSettingTab extends PluginSettingTa
             await this.plugin.saveSettings();
           })
       );
+    new Setting(containerEl)
+      .setName('Flat structure')
+      .setDesc('Do you want the notes in single files (flat, true) or in a hierarchical folder structure?')
+     .addToggle(toggle => {
+    toggle
+      .setValue(this.plugin.settings.flat_structure)
+      .onChange(async value => {
+        this.plugin.settings.flat_structure = value;
+        await this.plugin.saveSettings();
+      });
+    return toggle;
+  });
+
   }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -112,7 +112,7 @@ export class PocketbookCloudHighlightsImporterSettingTab extends PluginSettingTa
       );
     new Setting(containerEl)
       .setName('Flat structure')
-      .setDesc('Do you want the notes in single files (flat, true) or in a hierarchical folder structure?')
+      .setDesc('Do you want the highlights in a flat or in a nested folder structure? Enable this for flat structure. The nested structure creates separate files for each highlight and uses DataView to aggregate them in the parent file.')
      .addToggle(toggle => {
     toggle
       .setValue(this.plugin.settings.flat_structure)


### PR DESCRIPTION
See https://github.com/lenalebt/obsidian-pocketbook-cloud-highlight-importer/issues/5

Added a toggle in the settings to either use the current, nested structure with DataView OR a flat single file per book structure. The flat structure is opinionated and, e.g., removes the DataView section and add's a line to link to the author's name.

